### PR TITLE
AssetLink Equality

### DIFF
--- a/Mutagen.Bethesda.Core.UnitTests/Plugins/Assets/AssetLinkTests.cs
+++ b/Mutagen.Bethesda.Core.UnitTests/Plugins/Assets/AssetLinkTests.cs
@@ -71,4 +71,85 @@ public class AssetLinkTests
         link.RawPath.Should().Be(Path.Combine("SomeSubFolder", "SomeModel.nif"));
         link.DataRelativePath.Should().Be(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
     }
+    
+    [Fact]
+    public void TestEqualsDifferentRawPath()
+    {
+        var link = new AssetLinkGetter<TestAssetType>(Path.Combine("SomeSubFolder", "SomeModel.nif"));
+        var otherLink = new AssetLinkGetter<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        
+        link.Equals(otherLink).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void TestObjectEqualsGetterGetter()
+    {
+        var link = new AssetLinkGetter<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        var otherLink = new AssetLinkGetter<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        
+        Equals(link, otherLink).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void TestObjectEqualsGetterSetter()
+    {
+        var link = new AssetLinkGetter<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        var otherLink = new AssetLink<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        
+        Equals(link, otherLink).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void TestObjectEqualsSetterGetter()
+    {
+        var link = new AssetLink<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        var otherLink = new AssetLinkGetter<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        
+        Equals(link, otherLink).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void TestObjectEqualsSetterSetter()
+    {
+        var link = new AssetLink<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        var otherLink = new AssetLink<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        
+        Equals(link, otherLink).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void TestEqualsGetterGetter()
+    {
+        var link = new AssetLinkGetter<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        var otherLink = new AssetLinkGetter<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        
+        link.Equals(otherLink).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void TestEqualsGetterSetter()
+    {
+        var link = new AssetLinkGetter<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        var otherLink = new AssetLink<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        
+        link.Equals(otherLink).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void TestEqualsSetterGetter()
+    {
+        var link = new AssetLink<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        var otherLink = new AssetLinkGetter<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        
+        link.Equals(otherLink).Should().BeTrue();
+    }
+    
+    [Fact]
+    public void TestEqualsSetterSetter()
+    {
+        var link = new AssetLink<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        var otherLink = new AssetLink<TestAssetType>(Path.Combine("Meshes", "SomeSubFolder", "SomeModel.nif"));
+        
+        link.Equals(otherLink).Should().BeTrue();
+    }
 }

--- a/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
@@ -264,7 +264,7 @@ public class AssetLink<TAssetType> :
     {
         return HashCode.Combine(
                 typeof(TAssetType).GetHashCode(),
-                AssetLink.PathComparer.GetHashCode(RawPath));
+                AssetLink.PathComparer.GetHashCode(DataRelativePath));
     }
 
     public override bool Equals(object? other)
@@ -273,7 +273,7 @@ public class AssetLink<TAssetType> :
         if (ReferenceEquals(this, other)) return true;
         if (other is not IAssetLinkGetter<TAssetType> rhs) return false;
 
-        return AssetLink.PathComparer.Equals(RawPath, rhs.RawPath);
+        return AssetLink.PathComparer.Equals(DataRelativePath, rhs.DataRelativePath);
     }
 
     public virtual bool Equals(AssetLink<TAssetType>? other)
@@ -289,7 +289,7 @@ public class AssetLink<TAssetType> :
         if (ReferenceEquals(this, other)) return 0;
         if (ReferenceEquals(null, other)) return 1;
 
-        return AssetLink.PathComparer.Compare(RawPath, other.RawPath);
+        return AssetLink.PathComparer.Compare(DataRelativePath, other.DataRelativePath);
     }
 
     [return: NotNullIfNotNull("asset")]

--- a/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
@@ -271,7 +271,7 @@ public class AssetLink<TAssetType> :
     {
         if (ReferenceEquals(null, other)) return false;
         if (ReferenceEquals(this, other)) return true;
-        if (other is not AssetLink<TAssetType> rhs) return false;
+        if (other is not IAssetLinkGetter<TAssetType> rhs) return false;
 
         return AssetLink.PathComparer.Equals(RawPath, rhs.RawPath);
     }

--- a/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
+++ b/Mutagen.Bethesda.Core/Plugins/Assets/AssetLink.cs
@@ -149,6 +149,15 @@ public class AssetLinkGetter<TAssetType> : IComparable<AssetLinkGetter<TAssetTyp
         return DataRelativePath;
     }
 
+    public override bool Equals(object? other)
+    {
+        if (ReferenceEquals(null, other)) return false;
+        if (ReferenceEquals(this, other)) return true;
+        if (other is not IAssetLinkGetter<TAssetType> rhs) return false;
+
+        return AssetLink.PathComparer.Equals(DataRelativePath, rhs.DataRelativePath);
+    }
+
     public virtual bool Equals(AssetLinkGetter<TAssetType>? other)
     {
         if (ReferenceEquals(null, other)) return false;


### PR DESCRIPTION
Fixes issues reported in #474 and more.
The mentality on the equality operations was to report functionally equals paths as equal, which is why I opted to use DataRelativePath for all equality operations (this was inconsistent between DataRelativePath and RawPath before).