### PR TITLE
Revert "Removed "Scroll" enum entry of CastType. This mistake was brought over by xEdit. There is no setting like this in the CK."

### DIFF
--- a/Mutagen.Bethesda.Skyrim/Enums/CastType.cs
+++ b/Mutagen.Bethesda.Skyrim/Enums/CastType.cs
@@ -4,5 +4,6 @@ public enum CastType
 {
     ConstantEffect = 0,
     FireAndForget = 1,
-    Concentration = 2
+    Concentration = 2,
+    Scroll = 3,
 }


### PR DESCRIPTION
Sorry, this was a mistake